### PR TITLE
feat: add support for database url

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,19 +56,33 @@ ___
 Below are usage examples on how to use the Alembic Migration Checker for different types of supported databases within
 your GitHub Actions workflows.
 
-### 🐘 PostgreSQL Example
+### 🐘 PostgreSQL
 
-Please note that `db_type` is by default `postgresql`. So, for this type of database it is not necessary to specify it.
-Also, `db_port` is by default `5432`, specify the `db_port` only if you use a different one.
+You can specify the database connection using either a single connection string (`db_url`) or individual parameters. 
+Using `db_url` is convenient when the connection string is available as a single secret.
+
+#### Example Usage with `db_url`:
 
 ```yaml
 - name: Check Alembic Migration Version
-  uses: DevGlitch/alembic-migration-checker@v1
+  uses: DevGlitch/alembic-migration-checker@v1.1
   with:
-    db_url: ${{ secrets.DB_URL }}
-    # or specify individual parameters
+    db_url: ${{ secrets.DB_URL }}  # Format: postgresql+psycopg2://user:password@host:port/dbname
+    migrations_path: ./migrations/
+```
+
+#### Example Usage with Individual Parameters:
+
+If you prefer, you can specify individual parameters for the database connection. Please note that `db_type` defaults to 
+`postgresql`, so it is not necessary to specify it. Also, `db_port` defaults to `5432`, so specify `db_port` only if you are 
+using a different port.
+
+```yaml
+- name: Check Alembic Migration Version
+  uses: DevGlitch/alembic-migration-checker@v1.1
+  with:
     db_host: ${{ secrets.DB_HOST }}
-    db_port: ${{ secrets.DB_PORT }}  # Only if not using 5432 default port
+    db_port: ${{ secrets.DB_PORT }}  # Only if not using the default port 5432
     db_user: ${{ secrets.DB_USER }}
     db_password: ${{ secrets.DB_PASSWORD }}
     db_name: ${{ secrets.DB_NAME }}
@@ -77,15 +91,27 @@ Also, `db_port` is by default `5432`, specify the `db_port` only if you use a di
 
 ### 🐬 MySQL
 
-When working with MySQL, change the `db_type` to `mysql`. This example includes all necessary parameters for a MySQL
-database connection.
+When working with MySQL, set the `db_type` to `mysql`. You can specify the database connection using either a single 
+connection string (`db_url`) or individual parameters.
+
+#### Example Usage with `db_url`:
 
 ```yaml
 - name: Check Alembic Migration Version
-  uses: DevGlitch/alembic-migration-checker@v1
+  uses: DevGlitch/alembic-migration-checker@v1.1
   with:
-    db_url: ${{ secrets.DB_URL }}
-    # or specify individual parameters
+    db_url: ${{ secrets.DB_URL }}  # Format: mysql://user:password@host:port/dbname
+    migrations_path: ./migrations/
+```
+
+#### Example Usage with Individual Parameters:
+
+If you prefer, you can specify individual parameters for the database connection.
+
+```yaml
+- name: Check Alembic Migration Version
+  uses: DevGlitch/alembic-migration-checker@v1.1
+  with:
     db_type: mysql
     db_host: ${{ secrets.DB_HOST }}
     db_port: ${{ secrets.DB_PORT }}
@@ -97,15 +123,26 @@ database connection.
 
 ### 🪶 SQLite
 
-For SQLite databases, change the `db_type` to `sqlite`. The configuration is simplified
-as `db_host`, `db_port`, `db_user`, and `db_password` are not needed.
+For SQLite databases, you can either use a `db_url` to specify the entire database connection string or provide individual parameters. When using individual parameters, set the `db_type` to `sqlite`. Note that `db_host`, `db_port`, `db_user`, and `db_password` are not needed for SQLite.
+
+#### Example Usage with `db_url`:
 
 ```yaml
 - name: Check Alembic Migration Version
-  uses: DevGlitch/alembic-migration-checker@v1
+  uses: DevGlitch/alembic-migration-checker@v1.1
+  with:
+    db_url: ${{ secrets.DB_URL }}  # Format: sqlite:///path_to_db_file
+    migrations_path: ./migrations/
+```
+
+#### Example Usage with Individual Parameters:
+
+```yaml
+- name: Check Alembic Migration Version
+  uses: DevGlitch/alembic-migration-checker@v1.1
   with:
     db_type: sqlite
-    db_name: ${{ secrets.DB_NAME }}
+    db_name: ${{ secrets.DB_NAME }}  # Path to the SQLite database file
     migrations_path: ./migrations/
 ```
 
@@ -143,7 +180,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Check Alembic Migration Version
-        uses: DevGlitch/alembic-migration-checker@v1
+        uses: DevGlitch/alembic-migration-checker@v1.1
         with:
           db_host: ${{ secrets.DB_HOST }}
           db_name: ${{ secrets.DB_NAME }}
@@ -175,7 +212,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Check Alembic Migration Version
-        uses: DevGlitch/alembic-migration-checker@v1
+        uses: DevGlitch/alembic-migration-checker@v1.1
         with:
           db_host: ${{ secrets.STAGING_DB_HOST }}
           db_name: ${{ secrets.STAGING_DB_NAME }}

--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ This action supports various inputs to accommodate different database configurat
 
 _Note that some inputs are not required for all database types, such as SQLite._
 
+- `db_url`: The url of database to check. Alternative to `db_host`, `db_port`, `db_user`, `db_password`, and `db_name`.
 - `db_type`: The database type. Supported values are `postgresql`, `mysql`, and `sqlite`. Default: `postgresql`.
 - `db_host`: The database host address.
 - `db_port`: The database port. Defaults to `5432`.
@@ -64,6 +65,8 @@ Also, `db_port` is by default `5432`, specify the `db_port` only if you use a di
 - name: Check Alembic Migration Version
   uses: DevGlitch/alembic-migration-checker@v1
   with:
+    db_url: ${{ secrets.DB_URL }}
+    # or specify individual parameters
     db_host: ${{ secrets.DB_HOST }}
     db_port: ${{ secrets.DB_PORT }}  # Only if not using 5432 default port
     db_user: ${{ secrets.DB_USER }}
@@ -81,6 +84,8 @@ database connection.
 - name: Check Alembic Migration Version
   uses: DevGlitch/alembic-migration-checker@v1
   with:
+    db_url: ${{ secrets.DB_URL }}
+    # or specify individual parameters
     db_type: mysql
     db_host: ${{ secrets.DB_HOST }}
     db_port: ${{ secrets.DB_PORT }}

--- a/action.yml
+++ b/action.yml
@@ -5,6 +5,10 @@ branding:
   icon: "check-circle"
   color: "blue"
 inputs:
+  db_url:
+    description: "Database URL. Alternative to specifying individual database connection parameters. Default: ''"
+    required: false
+    default: ""
   db_type:
     description: "Database type. Supported types are 'postgresql', 'mysql', and 'sqlite'. Default: 'postgresql'"
     required: false
@@ -36,6 +40,7 @@ runs:
   using: "docker"
   image: "Dockerfile"
   args:
+    - ${{ inputs.db_url }}
     - ${{ inputs.db_type }}
     - ${{ inputs.db_host }}
     - ${{ inputs.db_port }}

--- a/action/entrypoint.sh
+++ b/action/entrypoint.sh
@@ -1,3 +1,3 @@
 #!/bin/sh -l
 
-python /check_alembic_migration.py --db_type="${INPUT_DB_TYPE}" --db_host="${INPUT_DB_HOST}" --db_port="${INPUT_DB_PORT}" --db_user="${INPUT_DB_USER}" --db_password="${INPUT_DB_PASSWORD}" --db_name="${INPUT_DB_NAME}" --migrations_path="${INPUT_MIGRATIONS_PATH}"
+python /check_alembic_migration.py --db_url="${INPUT_DB_URL}" --db_type="${INPUT_DB_TYPE}" --db_host="${INPUT_DB_HOST}" --db_port="${INPUT_DB_PORT}" --db_user="${INPUT_DB_USER}" --db_password="${INPUT_DB_PASSWORD}" --db_name="${INPUT_DB_NAME}" --migrations_path="${INPUT_MIGRATIONS_PATH}"

--- a/action/entrypoint.sh
+++ b/action/entrypoint.sh
@@ -1,3 +1,3 @@
 #!/bin/sh -l
 
-python /check_alembic_migration.py "${INPUT_DB_TYPE}" "${INPUT_DB_HOST}" "${INPUT_DB_PORT}" "${INPUT_DB_USER}" "${INPUT_DB_PASSWORD}" "${INPUT_DB_NAME}" "${INPUT_MIGRATIONS_PATH}"
+python /check_alembic_migration.py --db_type="${INPUT_DB_TYPE}" --db_host="${INPUT_DB_HOST}" --db_port="${INPUT_DB_PORT}" --db_user="${INPUT_DB_USER}" --db_password="${INPUT_DB_PASSWORD}" --db_name="${INPUT_DB_NAME}" --migrations_path="${INPUT_MIGRATIONS_PATH}"


### PR DESCRIPTION
Specifying all database parameters takes more effort than just using a plain database connection string, hence this PR aims to provide a way to consume database URL instead of constructing the URL inside the script

Also did some other minor refactors to improve the script.


Thank you for your work 